### PR TITLE
Fix cmake include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ target_include_directories(executionrl_lib PUBLIC include)
 
 add_executable(ExecutionRL src/main.cpp)
 target_link_libraries(ExecutionRL PRIVATE executionrl_lib)
+target_include_directories(ExecutionRL PRIVATE include)
 
 # === Tests ===
 enable_testing()


### PR DESCRIPTION
## Summary
- add include directory for `ExecutionRL` target

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6848ddd5b0948331a7b5cd011e551d77