### PR TITLE
Resolve PR#2 merge conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ set(LIB_SOURCES
 
 add_library(executionrl_lib ${LIB_SOURCES})
 target_include_directories(executionrl_lib PUBLIC include)
+target_compile_definitions(executionrl_lib PRIVATE DATA_PATH="${CMAKE_SOURCE_DIR}/data/price_series.csv")
 
 add_executable(ExecutionRL src/main.cpp)
 target_link_libraries(ExecutionRL PRIVATE executionrl_lib)
@@ -38,7 +39,12 @@ add_executable(test_simulation tests/test_simulation.cpp)
 target_link_libraries(test_agent PRIVATE executionrl_lib)
 target_link_libraries(test_env PRIVATE executionrl_lib)
 target_link_libraries(test_simulation PRIVATE executionrl_lib)
+target_include_directories(test_agent PRIVATE include)
+target_include_directories(test_env PRIVATE include)
+target_include_directories(test_simulation PRIVATE include)
 
 add_test(NAME AgentTest COMMAND test_agent)
 add_test(NAME EnvTest COMMAND test_env)
 add_test(NAME SimulationTest COMMAND test_simulation)
+set_tests_properties(AgentTest EnvTest SimulationTest
+    PROPERTIES WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})

--- a/include/core/ExecutionSimulator.cpp
+++ b/include/core/ExecutionSimulator.cpp
@@ -3,13 +3,15 @@
 ExecutionSimulator::ExecutionSimulator(MarketEnvironment& env, QLearningAgent& agent)
     : env(env), agent(agent) {}
 
-void ExecutionSimulator::run() {
-    env.reset();
-    while (!env.isDone()) {
-        auto state = env.getState();
-        int action = agent.chooseAction(state);
-        double reward = env.step(action);
-        auto nextState = env.getState();
-        agent.update(state, action, reward, nextState);
+void ExecutionSimulator::run(int episodes) {
+    for (int i = 0; i < episodes; ++i) {
+        env.reset();
+        while (!env.isDone()) {
+            auto state = env.getState();
+            int action = agent.chooseAction(state);
+            double reward = env.step(action);
+            auto nextState = env.getState();
+            agent.update(state, action, reward, nextState);
+        }
     }
 }

--- a/include/core/ExecutionSimulator.hpp
+++ b/include/core/ExecutionSimulator.hpp
@@ -8,7 +8,7 @@
 class ExecutionSimulator {
 public:
     ExecutionSimulator(MarketEnvironment& env, QLearningAgent& agent);
-    void run();
+    void run(int episodes = 1);
 
 private:
     MarketEnvironment& env;

--- a/include/env/MarketEnvironment.cpp
+++ b/include/env/MarketEnvironment.cpp
@@ -40,7 +40,7 @@ bool MarketEnvironment::isDone() const {
 }
 
 void MarketEnvironment::loadMarketData() {
-    std::ifstream file("data/price_series.csv");
+    std::ifstream file(DATA_PATH);
     if (!file.is_open()) {
         file.open("../data/price_series.csv");
     }

--- a/tests/test_agent.cpp
+++ b/tests/test_agent.cpp
@@ -1,4 +1,4 @@
-#include "../include/agents/QLearningAgent.hpp"
+#include "agents/QLearningAgent.hpp"
 #include <cassert>
 #include <iostream>
 

--- a/tests/test_env.cpp
+++ b/tests/test_env.cpp
@@ -1,4 +1,4 @@
-#include "../include/env/MarketEnvironment.hpp"
+#include "env/MarketEnvironment.hpp"
 #include <cassert>
 #include <iostream>
 

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -1,7 +1,7 @@
-#include "../include/core/ExecutionSimulator.hpp"
-#include "../include/env/MarketEnvironment.hpp"
-#include "../include/agents/QLearningAgent.hpp"
-#include "../include/config.hpp"
+#include "core/ExecutionSimulator.hpp"
+#include "env/MarketEnvironment.hpp"
+#include "agents/QLearningAgent.hpp"
+#include "config.hpp"
 #include <iostream>
 
 int main() {


### PR DESCRIPTION
## Summary
- allow `ExecutionSimulator` to run multiple episodes
- use a compile-time DATA_PATH for price data
- link tests against the library and set working directory
- clean up test include paths

## Testing
- `cmake .. && cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6848df808efc8331838884456f9f4080